### PR TITLE
fix(container): ignore DL3066 for named USER

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023-2025 David Rabkin
+# SPDX-FileCopyrightText: 2023-2026 David Rabkin
 # SPDX-License-Identifier: 0BSD
 FROM registry.access.redhat.com/ubi8/ubi:8.10
 LABEL maintainer=David\ Rabkin\ <david@rabkin.co.il>
@@ -20,6 +20,7 @@ RUN \
 		bash-4.4.20 \
 		findutils-4.6.0 \
 	&& dnf clean all --disableplugin=subscription-manager
+# hadolint ignore=DL3066
 USER "$USER"
 WORKDIR /home/"$USER"
 COPY \


### PR DESCRIPTION
## Summary
- hadolint v2.15.0 (bundled by hadolint-action 3.4.0, see dependabot PR #56) added rule DL3066, which flags the non-numeric `USER` in `Containerfile`
- The user id is created dynamically by the base image tooling, so a fixed numeric UID isn't available; suppress the new rule inline instead

## Test plan
- [x] `hadolint ./Containerfile` passes locally (exit 0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the copyright year to include 2026.
  * Adjusted container build checks to accommodate the existing user configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->